### PR TITLE
fix: make the bundle in the release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,9 @@ jobs:
       - name: build container image
         run: |
           VERSION='${{ steps.image_tag.outputs.tag }}' make docker-build
-          VERSION='${{ steps.image_tag.outputs.tag }}' make bundle-build
       - name: push images to quay
         run: |
           VERSION='${{ steps.image_tag.outputs.tag }}' make docker-push
-          VERSION='${{ steps.image_tag.outputs.tag }}' make bundle-push
       - name: success slack notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.commit_ref }}
+      - name: install-yq
+        run: |
+          echo "installing yq..."
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+          echo "yq installed"
       - name: build
         run: |
           VERSION=${{ github.event.inputs.tag }} make docker-build
+          rm -rf bundle/
+          VERSION=${{ github.event.inputs.tag }} make bundle
           VERSION=${{ github.event.inputs.tag }} make bundle-build
       - run: echo "${{ secrets.QUAY_BOT_PASSWORD }}" | docker login --username "${{ secrets.QUAY_BOT_USERNAME }}" --password-stdin quay.io
       - name: push the image to quay

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,11 @@ endif
 
 .PHONY: bundle
 bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+	@echo 'changing the image tag to '${VERSION}' in "containerImage" field in the CSV using yq'
+	@cat config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
+	yq eval --exit-status --inplace ".metadata.annotations.containerImage=\"quay.io/konveyor/move2kube-operator:${VERSION}\"" config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
+	@echo 'after editting the CSV'
+	@cat config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)

--- a/bundle/manifests/move2kube-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/move2kube-operator.clusterserviceversion.yaml
@@ -80,7 +80,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Modernization & Migration
     containerImage: quay.io/konveyor/move2kube-operator:v0.3.9
-    createdAt: "2023-08-23T19:28:57Z"
+    createdAt: "2023-08-24T14:46:14Z"
     description: Konveyor Move2Kube is an open source tool that helps migrate your
       app to run on Kubernetes/Openshift.
     operators.operatorframework.io/builder: operator-sdk-v1.31.0


### PR DESCRIPTION
remove bundle build from the build workflow since we can't use the latest tag